### PR TITLE
Added support for multiple constraint names

### DIFF
--- a/jarb-constraints/src/main/java/org/jarbframework/constraint/violation/factory/ConfigurableConstraintExceptionFactory.java
+++ b/jarb-constraints/src/main/java/org/jarbframework/constraint/violation/factory/ConfigurableConstraintExceptionFactory.java
@@ -60,24 +60,24 @@ public class ConfigurableConstraintExceptionFactory implements DatabaseConstrain
 
     /**
      * Register a custom exception for a constraint.
-     * @param constraintName name of the constraint
+     * @param constraintNames name of the constraint
      * @param matchingStrategy strategy used for matching
      * @param exceptionClass class of the exception (factory)
      * @return this factory instance, for chaining
      */
-    public ConfigurableConstraintExceptionFactory register(String constraintName, NameMatchingStrategy matchingStrategy, Class<?> exceptionClass) {
-        return register(constraintName, matchingStrategy, new ReflectionConstraintExceptionFactory(exceptionClass));
+    public ConfigurableConstraintExceptionFactory register(String[] constraintNames, NameMatchingStrategy matchingStrategy, Class<?> exceptionClass) {
+        return register(constraintNames, matchingStrategy, new ReflectionConstraintExceptionFactory(exceptionClass));
     }
     
     /**
      * Register a custom exception factory for a constraint.
-     * @param constraintName name of the constraint
+     * @param constraintNames name of the constraint
      * @param matchingStrategy strategy used for matching
      * @param exceptionFactory creates the exception
      * @return this factory instance, for chaining
      */
-    public ConfigurableConstraintExceptionFactory register(String constraintName, NameMatchingStrategy matchingStrategy, DatabaseConstraintExceptionFactory exceptionFactory) {
-        return register(new NameMatchingPredicate(constraintName, matchingStrategy), exceptionFactory);
+    public ConfigurableConstraintExceptionFactory register(String[] constraintNames, NameMatchingStrategy matchingStrategy, DatabaseConstraintExceptionFactory exceptionFactory) {
+        return register(new NameMatchingPredicate(constraintNames, matchingStrategy), exceptionFactory);
     }
 
     /**

--- a/jarb-constraints/src/main/java/org/jarbframework/constraint/violation/factory/NameMatchingPredicate.java
+++ b/jarb-constraints/src/main/java/org/jarbframework/constraint/violation/factory/NameMatchingPredicate.java
@@ -3,6 +3,8 @@ package org.jarbframework.constraint.violation.factory;
 import org.jarbframework.constraint.violation.DatabaseConstraintViolation;
 import org.jarbframework.utils.StringUtils;
 
+import java.util.Arrays;
+
 /**
  * Matches constraint violations based on their constraint name.
  * @author Jeroen van Schagen
@@ -11,18 +13,18 @@ import org.jarbframework.utils.StringUtils;
 public class NameMatchingPredicate implements ViolationPredicate {
     
 	/** The expected constraint name. */
-    private final String expectedName;
+    private final String[] expectedNames;
     
     /** The matching strategy used to compare constraint names. */
     private final NameMatchingStrategy matchingStrategy;
     
     /**
      * Construct a new predicate.
-     * @param constraintName the expected constraint name
+     * @param constraintNames the expected constraint name
      * @param matchingStrategy the matching strategy to use
      */
-    public NameMatchingPredicate(String constraintName, NameMatchingStrategy matchingStrategy) {
-        this.expectedName = constraintName;
+    public NameMatchingPredicate(String[] constraintNames, NameMatchingStrategy matchingStrategy) {
+        this.expectedNames = constraintNames;
         this.matchingStrategy = matchingStrategy;
     }
 
@@ -32,7 +34,7 @@ public class NameMatchingPredicate implements ViolationPredicate {
     	
         String actualName = violation.getConstraintName();
         if (StringUtils.isNotBlank(actualName)) {
-        	matches = matchingStrategy.matches(expectedName, actualName);
+            matches = Arrays.stream(expectedNames).anyMatch(expected -> expected.matches(actualName));
         }
         
         return matches;

--- a/jarb-constraints/src/main/java/org/jarbframework/constraint/violation/factory/NamedConstraint.java
+++ b/jarb-constraints/src/main/java/org/jarbframework/constraint/violation/factory/NamedConstraint.java
@@ -19,8 +19,8 @@ public @interface NamedConstraint {
      * Name of the constraint <b>required</b>.
      * @return constraint name
      */
-    String value();
-    
+    String[] value();
+
     /**
      * Strategy used to match the name.
      * @return matching strategy

--- a/jarb-constraints/src/test/java/org/jarbframework/constraint/violation/factory/ConfigurableConstraintExceptionFactoryTest.java
+++ b/jarb-constraints/src/test/java/org/jarbframework/constraint/violation/factory/ConfigurableConstraintExceptionFactoryTest.java
@@ -23,7 +23,7 @@ public class ConfigurableConstraintExceptionFactoryTest {
 
     @Test
     public void testCustomException() {
-        exceptionFactory.register(violation.getConstraintName(), EXACT, CarAlreadyExistsException.class);
+        exceptionFactory.register(new String[]{violation.getConstraintName()}, EXACT, CarAlreadyExistsException.class);
         Throwable exception = exceptionFactory.buildException(violation, null);
         assertTrue(exception instanceof CarAlreadyExistsException);
     }

--- a/jarb-constraints/src/test/java/org/jarbframework/constraint/violation/factory/mapping/NameMatchingPredicateTest.java
+++ b/jarb-constraints/src/test/java/org/jarbframework/constraint/violation/factory/mapping/NameMatchingPredicateTest.java
@@ -14,7 +14,7 @@ public class NameMatchingPredicateTest {
 	
 	@Before
 	public void setUp() {
-		nameMatchingPredicate = new NameMatchingPredicate("uk_person_name", NameMatchingStrategy.EXACT);
+		nameMatchingPredicate = new NameMatchingPredicate(new String[]{"uk_person_name"}, NameMatchingStrategy.EXACT);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #38

You can have multiple constraints which generate the same error.
This allows you to group them under one exception