### PR TITLE
The BeanConstraintService now handles @Embeddable.

### DIFF
--- a/jarb-constraints/src/main/java/org/jarbframework/constraint/metadata/BeanConstraintService.java
+++ b/jarb-constraints/src/main/java/org/jarbframework/constraint/metadata/BeanConstraintService.java
@@ -39,7 +39,7 @@ public class BeanConstraintService {
         Map<String, Map<String, PropertyConstraintDescription>> descriptions = new HashMap<>();
         for (Class<?> entityClass : entityClasses) {
             Map<String, PropertyConstraintDescription> properties = describe(entityClass);
-            descriptions.put(getEntityName(entityClass), properties);
+            descriptions.put(entityClass.getSimpleName(), properties);
         }
         return descriptions;
     }
@@ -56,9 +56,6 @@ public class BeanConstraintService {
         return properties;
     }
 
-    protected String getEntityName(Class<?> entityClass) {
-        return entityClass.getName();
-    }
 
     public void registerClass(Class<?> entityClass) {
         entityClasses.add(entityClass);

--- a/jarb-constraints/src/test/java/org/jarbframework/constraint/metadata/BeanConstraintServiceTest.java
+++ b/jarb-constraints/src/test/java/org/jarbframework/constraint/metadata/BeanConstraintServiceTest.java
@@ -74,8 +74,40 @@ public class BeanConstraintServiceTest {
         assertTrue(service.describeAll().isEmpty());
         
         service.registerAllWithAnnotation(TestConstraintsConfig.class, Entity.class);
-        
-        assertFalse(service.describeAll().isEmpty());
+
+        Map<String, Map<String, PropertyConstraintDescription>> constraints  = service.describeAll();
+        assertFalse(constraints.isEmpty());
+
+        // Testing the Person
+        Map<String, PropertyConstraintDescription> person = constraints.get("Person");
+
+        PropertyConstraintDescription name = person.get("name");
+        assertEquals(255, name.getMaximumLength().longValue());
+        assertTrue(name.isRequired());
+
+        PropertyConstraintDescription city = person.get("contact.address.city");
+        assertEquals(255, city.getMaximumLength().longValue());
+        assertTrue(city.isRequired());
+
+        PropertyConstraintDescription streetAndNumber = person.get("contact.address.streetAndNumber");
+        assertEquals(255, streetAndNumber.getMaximumLength().longValue());
+        assertTrue(streetAndNumber.isRequired());
+
+        // Testing the Car
+        Map<String, PropertyConstraintDescription> car = constraints.get("Car");
+
+        PropertyConstraintDescription licenseNumber = car.get("licenseNumber");
+        assertEquals(6, licenseNumber.getMaximumLength().longValue());
+        assertTrue(licenseNumber.isRequired());
+
+        PropertyConstraintDescription price = car.get("price");
+        assertEquals(6, price.getMaximumLength().longValue());
+        assertFalse(price.isRequired());
+        assertEquals(2, price.getFractionLength().longValue());
+        assertEquals(10, price.getRadix().longValue());
+
+        PropertyConstraintDescription active = car.get("active");
+        assertFalse(active.isRequired());
     }
 
     @Configuration


### PR DESCRIPTION
For example when a Person has an @Embeddable Contact which in turn
has an @Embeddable Address it will now return constraints for each
field of the embeddable.

The end result is a HashMap<String, PropertyConstraintDescription> that
will look like this:

```
{
  "name": #PropertyConstraintDescription
  "contract.address.city": #PropertyConstraintDescription
  "contract.address.streetAndName": #PropertyConstraintDescription
}
```

Each embeddable will start a new '.' in the key name.

Closes #41.