### PR TITLE
javax.el-api can be set as provided because it is part of the tomcat …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
             <version>3.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javassist</groupId>


### PR DESCRIPTION
…distribution.