### PR TITLE
Updated to Spring Boot 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Update
+- Updated to Spring Boot 3
+- Updated to Hibernate Core 6.2.2.Final
+
 ## [5.3.0] - 20-05-2019
 - Support @ElementCollection collection/map JPA mappings in bean meta-model
 - Support javax validation annotations:

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <java.version>17</java.version>
 
         <!-- Dependency versions -->
-        <spring-boot.version>3.0.2</spring-boot.version>
+        <spring-boot.version>3.1.0</spring-boot.version>
         <testcontainers.version>1.17.3</testcontainers.version>
     </properties>
 
@@ -215,8 +215,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/nl/_42/jarb/autoconfigure/JarbAutoConfig.java
+++ b/src/main/java/nl/_42/jarb/autoconfigure/JarbAutoConfig.java
@@ -1,11 +1,14 @@
 package nl._42.jarb.autoconfigure;
 
+import nl._42.jarb.constraint.DatabaseConstraintsConfiguration;
 import nl._42.jarb.constraint.metadata.BeanConstraintController;
 import nl._42.jarb.constraint.metadata.BeanConstraintService;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 /**
@@ -23,6 +26,7 @@ public class JarbAutoConfig {
     }
 
     @Bean
+    @DependsOn("beanConstraintService")
     @ConditionalOnMissingBean(BeanConstraintController.class)
     public BeanConstraintController beanConstraintController(BeanConstraintService beanConstraintService) {
         return new BeanConstraintController(beanConstraintService);


### PR DESCRIPTION
- Updated dependencies
- Updated JarbAutoConfig, setting the BeanConstraintController-bean to depend on the BeanConstraintService-bean.
- Updated HibernateJpaSchemaMapper, setting the minimum hibernate-core version to 6.2.2.Final (Spring Boot 3.1's default).